### PR TITLE
Change to DifferentialEquations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
-
 Cubature
-ODE
+DiffEqBase
+OrdinaryDiffEq

--- a/src/GalerkinSparseGrids.jl
+++ b/src/GalerkinSparseGrids.jl
@@ -3,7 +3,7 @@ module GalerkinSparseGrids
 # The prerequisite packages as of March 2017 are Cubature.jl and ODE.jl
 
 using Cubature
-using ODE
+using DiffEqBase, OrdinaryDiffEq
 
 # The following script files are used
 
@@ -13,7 +13,7 @@ include("DG_Basis.jl")	  			   # Gram-Schmidt procedure for DG basis functions i
 include("1D_DG_Functions.jl") 		   # Explicitly building the 1-D Galerkin Basis
 include("DG_Methods.jl") 			   # Multidimensional hierarchical & sparse coefficients
 include("DG_vMethods.jl") 			   # Going between a dictionary & a vector of coeffs
-include("DG_Derivative_Matrix_Elements.jl") 		   # 1-D symbolic piecewise derivative 
+include("DG_Derivative_Matrix_Elements.jl") 		   # 1-D symbolic piecewise derivative
 include("DG_Derivative_Precompute.jl") # Precomputing derivative matrix for coeff vect
 include("Derivative_LF_1D.jl") 	   	   # Constructing ideal 1D derivative matrix using boundary terms
 include("Multidim_Derivative.jl") 	   # Multidimensional DG Derivatives in full & sparse bases
@@ -25,11 +25,11 @@ include("Tensor_Construct.jl") 		   # Quickly calculates coeffs of `simple tenso
 include("Traveling_Wave_Example.jl")
 
 
-# make naming scheme more systematic 
+# make naming scheme more systematic
 export standard_coeffs
 export standard_reconstruct
 export coeffs_hat
-export reconstruct_hat 
+export reconstruct_hat
 
 export coeffs_DG
 export reconstruct_DG

--- a/src/PDEs.jl
+++ b/src/PDEs.jl
@@ -43,7 +43,7 @@ function wave_evolve_1D(k::Int, max_level::Int,
 		end
 	end
 	y0 = Array{Float64}([i<=len?f0coeffs[i]:v0coeffs[i-len] for i in 1:2*len])
-	soln = solve(ODEProblem((t,x)->*(RHS,x), y0, (float(time0),float(time1))),alg)
+	soln = solve(ODEProblem((t,x,dx)->A_mul_B!(dx,RHS,x), y0, (float(time0),float(time1))),alg)
 	return soln
 end
 
@@ -102,7 +102,7 @@ function wave_evolve(D::Int, k::Int, n::Int,
 	RHS = sparse(I, J, V, 2*len, 2*len, +)
 
 	y0 = Array{Float64}([i<=len?f0coeffs[i]:v0coeffs[i-len] for i in 1:2*len])
-	soln = solve(ODEProblem((t,x)->*(RHS,x), y0, (float(time0),float(time1))),alg)
+	soln = solve(ODEProblem((t,x,dx)->A_mul_B!(dx,RHS,x), y0, (float(time0),float(time1))),alg)
 	return soln
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using GalerkinSparseGrids
 using Base.Test
 using Cubature
-using ODE
+using OrdinaryDiffEq
 
 println("Beginning Tests of GalerkinSparseGrids.jl--------------------------------------")
 
@@ -297,10 +297,10 @@ k = 4
 level = 4
 f0 = x->sin(2*pi*x[1])
 v0 = x->2*pi*cos(2*pi*x[1])
-pos_soln = wave_evolve_1D(k, level, f0, v0, 0, 1; base="pos", order="45")
+pos_soln = wave_evolve_1D(k, level, f0, v0, 0, 1; base="pos", alg=Tsit5())
 energy_soln = energy_func_1D(k, level, pos_soln; base="pos")
 for i in 1:length(energy_soln[2])
-    @test abs(sqrt(energy_soln[2][i])-2*pi)<=1.0e-7
+    @test abs(sqrt(energy_soln[2][i])-2*pi)<=1.0e-6
 end
 
 println("Test Passed.")
@@ -309,10 +309,10 @@ println("Test Passed.")
 
 print("Testing wave equation solver 1-D hierarchical DG basis... ")
 
-hier_soln  = wave_evolve_1D(k, level, f0, v0, 0, 1; base="hier", order="45")
+hier_soln  = wave_evolve_1D(k, level, f0, v0, 0, 1; base="hier", alg=Tsit5())
 energy_soln = energy_func_1D(k, level, hier_soln; base="hier")
 for i in 1:length(energy_soln[2])
-    @test abs(sqrt(energy_soln[2][i])-2*pi)<=1.0e-7
+    @test abs(sqrt(energy_soln[2][i])-2*pi)<=1.0e-6
 end
 
 println("Test Passed.")
@@ -328,7 +328,7 @@ println("Test Passed.")
 # n_used = 5
 # f0 = x->sin(2*pi*x[1])*sin(2*pi*x[2])
 # v0 = x->0
-# sparse_soln = wave_evolve(D, k_used, n_used, f0, v0, 0,1; order="78", scheme="sparse");
+# sparse_soln = wave_evolve(D, k_used, n_used, f0, v0, 0,1; alg=Vern7(), scheme="sparse");
 # senergy = energy_func(D, k_used, n_used, sparse_soln)
 # @test senergy[2][1]-senergy[2][end] > 0
 # @test abs(senergy[2][1]-senergy[2][end]) < 1.0e-8
@@ -336,7 +336,7 @@ println("Test Passed.")
 #     @test abs(sqrt(senergy[2][i])-sqrt(2)*pi) <= 1.0e-4
 # end
 #
-# sparse_soln = wave_evolve(D, k_used, n_used, f0, v0, 0,1; order="45", scheme="sparse");
+# sparse_soln = wave_evolve(D, k_used, n_used, f0, v0, 0,1; alg=Tsit5(), scheme="sparse");
 # senergy = energy_func(D, k_used, n_used, sparse_soln)
 # @test senergy[2][1]-senergy[2][end]>0
 # @test abs(senergy[2][1]-senergy[2][end])<1.0e-8
@@ -355,11 +355,11 @@ println("Test Passed.")
 # k_used = 3
 # n_used = 6
 #
-# soln = traveling_wave_solver(k_used, n_used, m, 0, 0.54; order="45")
+# soln = traveling_wave_solver(k_used, n_used, m, 0, 0.54; alg=Tsit5())
 # dict = V2D(D, k_used, n_used, soln[2][end]; scheme="sparse")
 # @test mcerr(x->reconstruct_DG(dict, [x...]), truesoln, D) < 0.05
 #
-# soln = traveling_wave_solver(k_used, n_used, m, 0, 0.54; order="78")
+# soln = traveling_wave_solver(k_used, n_used, m, 0, 0.54; alg=Vern7())
 # dict = V2D(D, k_used, n_used, soln[2][end]; scheme="sparse")
 # @test mcerr(x->reconstruct_DG(dict, [x...]), truesoln, D) < 0.05
 #


### PR DESCRIPTION
This changes the internal time stepping solvers to use the DifferentialEquations.jl interface. This makes it compatible with all of the solvers on DifferentialEquations, including OrdinaryDiffEq.jl, Sundials.jl, ODEInterface.jl, ODE.jl, etc. The OrdinaryDiffEq.jl requirement is only needed because of the default algorithm setting `Tsit5()`. The formulation was also changed to in-place updates. Additionally, the passing of keyword args makes the full interface available.

This should not only make you immune to further deprecation of ODE.jl, but also should make this much more efficient.

@smldis